### PR TITLE
Add button that preps the blend file for submission to a render farm.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -522,7 +522,7 @@ class CameraShakesFixGlobal(bpy.types.Operator):
 
 
 class CameraShakifyPrepFileForFarm(bpy.types.Operator):
-    """Adds an auto-execute script to the blend file that makes Camera Shakes work even when the addon is not present. Particularly useful for sending files to a render farm. This only needs to be run once, not every time you submit the file to a farm"""
+    """Adds an auto-execute script to the blend file that makes Camera Shakes work even when the addon is not present. Particularly useful for sending files to a render farm. This only needs to be run once per file, not every time you submit a file to a farm"""
     bl_idname = "wm.camera_shakify_prep_file_for_farm"
     bl_label = "Prep Blend File For Render Farm"
     bl_options = {'UNDO'}

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "camera_shakify"
-version = "0.4.0"
+version = "0.3.0"
 name = "Camera Shakify"
 tagline = "Add captured camera shake/wobble to your cameras"
 maintainer = "Nathan Vegadahl <cessen@cessen.com>"
@@ -15,9 +15,9 @@ website = "https://github.com/EatTheFuture/camera_shakify/"
 tags = ["Animation", "Camera"]
 
 blender_version_min = "4.2.0"
-# Optional: Blender version that the extension does not support, earlier versions are supported.
-# This can be omitted and defined later on the extensions platform if an issue is found.
-blender_version_max = "4.4.0"
+# # Optional: Blender version that the extension does not support, earlier versions are supported.
+# # This can be omitted and defined later on the extensions platform if an issue is found.
+# blender_version_max = "5.1.0"
 
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
 # https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
@@ -25,7 +25,7 @@ license = [
   "SPDX:GPL-3.0-or-later",
 ]
 copyright = [
-  "2021-2025 Ian Hubert & Nathan Vegdahl",
+  "2021-2024 Ian Hubert & Nathan Vegdahl",
 ]
 
 # Optional list of supported platforms. If omitted, the extension will be available in all operating systems.

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "camera_shakify"
-version = "0.3.0"
+version = "0.4.0"
 name = "Camera Shakify"
 tagline = "Add captured camera shake/wobble to your cameras"
 maintainer = "Nathan Vegadahl <cessen@cessen.com>"
@@ -15,9 +15,9 @@ website = "https://github.com/EatTheFuture/camera_shakify/"
 tags = ["Animation", "Camera"]
 
 blender_version_min = "4.2.0"
-# # Optional: Blender version that the extension does not support, earlier versions are supported.
-# # This can be omitted and defined later on the extensions platform if an issue is found.
-# blender_version_max = "5.1.0"
+# Optional: Blender version that the extension does not support, earlier versions are supported.
+# This can be omitted and defined later on the extensions platform if an issue is found.
+blender_version_max = "4.4.0"
 
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
 # https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
@@ -25,7 +25,7 @@ license = [
   "SPDX:GPL-3.0-or-later",
 ]
 copyright = [
-  "2021-2024 Ian Hubert & Nathan Vegdahl",
+  "2021-2025 Ian Hubert & Nathan Vegdahl",
 ]
 
 # Optional list of supported platforms. If omitted, the extension will be available in all operating systems.

--- a/farm_script.py
+++ b/farm_script.py
@@ -1,0 +1,89 @@
+# Code for managing a blend-file-local script that registers the minimal types
+# and properties needed for Camera Shakify shakes to animate even without Camera
+# Shakify installed. Useful mainly for submitting files to render farms.
+
+import bpy
+
+FARM_SCRIPT_NAME = "camera_shakify_init.py"
+
+FARM_SCRIPT_CONTENTS = """\
+import bpy
+
+class CameraShakeInstance(bpy.types.PropertyGroup):
+    # Don't include the shake type in this stand-in version of the class, as it's not necessary
+    # for the shakes to animate (only for managing the shakes), and it would require including
+    # a bunch more cruft in this script.
+    #
+    # shake_type: bpy.props.EnumProperty(
+    #     name = "Shake Type",
+    #     items = [(id, SHAKE_LIST[id][0], "") for id in SHAKE_LIST.keys()],
+    #     options = set(), # Not animatable.
+    #     override = set(), # Not library overridable.
+    #     update = on_shake_type_update,
+    # )
+
+    influence: bpy.props.FloatProperty(
+        name="Influence",
+        description="How much the camera shake affects the camera",
+        default=1.0,
+        min=0.0, max={influence_max},
+        soft_min=0.0, soft_max=1.0,
+    )
+    scale: bpy.props.FloatProperty(
+        name="Scale",
+        description="The scale of the shake's location component",
+        default=1.0,
+        min=0.0, max={scale_max},
+        soft_min=0.0, soft_max=2.0,
+    )
+    use_manual_timing: bpy.props.BoolProperty(
+        name="Manual Timing",
+        description="Manually animate the progression of time through the camera shake animation",
+        default=False,
+    )
+    time: bpy.props.FloatProperty(
+        name="Time",
+        description="Current time (in frame number) of the shake animation",
+        default=0.0,
+        precision=1,
+        step=100.0,
+    )
+    speed: bpy.props.FloatProperty(
+        name="Speed",
+        description="Multiplier for how fast the shake animation plays",
+        default=1.0,
+        soft_min=0.0, soft_max=4.0,
+        options = set(), # Not animatable.
+    )
+    offset: bpy.props.FloatProperty(
+        name="Frame Offset",
+        description="How many frames to offset the shake animation",
+        default=0.0,
+        precision=1,
+        step=100.0,
+    )
+
+if __name__ == "__main__":
+    # Only register the property if it doesn't already exist.  This is to guard against replacing
+    # the property with the stand-in class when the real one from the addon already exists.
+    if not hasattr(bpy.types.Object, "camera_shakes"):
+        bpy.utils.register_class(CameraShakeInstance)
+        bpy.types.Object.camera_shakes = bpy.props.Collection
+"""
+
+
+def ensure_farm_script(influence_max, scale_max):
+    # Get existing script if it exists, or create it otherwise.
+    if FARM_SCRIPT_NAME in bpy.data.texts:
+        script = bpy.data.texts[FARM_SCRIPT_NAME]
+    else:
+        script = bpy.data.texts.new(FARM_SCRIPT_NAME)
+
+    script.clear()
+    script.write(FARM_SCRIPT_CONTENTS.format(influence_max = influence_max, scale_max = scale_max))
+
+    # Make sure it doesn't get garbage collected.
+    script.use_fake_user = True
+
+    # Mark for auto-execute on file load.
+    script.use_module = True

--- a/farm_script.py
+++ b/farm_script.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     # the property with the stand-in class when the real one from the addon already exists.
     if not hasattr(bpy.types.Object, "camera_shakes"):
         bpy.utils.register_class(CameraShakeInstance)
-        bpy.types.Object.camera_shakes = bpy.props.Collection
+        bpy.types.Object.camera_shakes = bpy.props.CollectionProperty(type=CameraShakeInstance)
 """
 
 


### PR DESCRIPTION
The button creates a Python script in the blend file that registers the minimal
types and properties needed for Camera Shakify shakes to animate, and marks that
script to auto-execute on file load.  That way when loading the file in a
Blender without Camera Shakify installed, the camera shakes continue to work
(although there is no good way to manipulate or change them).

This is mainly intended for submitting blend files with Camera Shakify shakes to
render farms, but it might have other uses as well.
