### PR TITLE
Update Camera Shakify to use slotted actions properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## [Unreleased]
 
+- Update code to work properly with the new slotted/layered Action APIs in Blender 4.4.
+
 
 ## [0.4.0] - 2024-02-21
 

--- a/__init__.py
+++ b/__init__.py
@@ -36,15 +36,19 @@ from .action_utils import action_to_python_data_text, ensure_shake_in_action, ac
 from .shake_data import SHAKE_LIST
 from .farm_script import ensure_farm_script
 
-BASE_NAME = "CameraShakify.v4"
-ACTION_NAME = BASE_NAME
+# Note: the ".v#" number at the end is *not* the addon version.  This number is
+# incremented when the way shakes are constructed changes to prevent
+# compatibility problems, and generally spans multiple addon versions.
+BASE_NAME = "CameraShakify.v3"
+ACTION_NAME = BASE_NAME + " Shakes"
 COLLECTION_NAME = BASE_NAME
 
 # Note: the addon used to be called "Camera Wobble" before it was publicly
 # released, and had a "v1" and "v2" base name under that name.  We don't include
 # those here because those versions of the addon were only ever used internally
 # by Ian, and there should be no files that exist anymore that use those base
-# names.
+# names.  But that's why there's also no "CameraShakify.v1", because that never
+# existed.
 BASE_NAMES_OLD = ["CameraShakify.v2"]
 
 # Maximum values of our per-camera scaling/influence properties.

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -14,10 +14,10 @@ website = "https://github.com/EatTheFuture/camera_shakify/"
 # https://docs.blender.org/manual/en/dev/advanced/extensions/tags.html
 tags = ["Animation", "Camera"]
 
-blender_version_min = "4.2.0"
-# Optional: Blender version that the extension does not support, earlier versions are supported.
-# This can be omitted and defined later on the extensions platform if an issue is found.
-blender_version_max = "4.4.0"
+blender_version_min = "4.4.0"
+# # Optional: Blender version that the extension does not support, earlier versions are supported.
+# # This can be omitted and defined later on the extensions platform if an issue is found.
+# blender_version_max = "5.0.0"
 
 # License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
 # https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html


### PR DESCRIPTION
The way Actions work has fundamentally changed in Blender 4.4, along with their
Python APIs.  The old Python APIs still work thanks to backwards compatibility
shims, but those shims are slated for removal in Blender 5.0 and addons are
encouraged to update to the new APIs as soon as possible.

This PR updates Camera Shakify to use those new slotted action APIs.

As a bonus, Camera Shakify now stores all of its camera shakes in a single
action via the slot system, rather than polluting the action list in a blend
file with a whole action per shake.

This PR also does some other misc unrelated cleanups that I noticed needed
doing.  Ideally I should have split those into separate commits, but this is
effectively a one-man project at the moment and I'm feeling too lazy to do that.